### PR TITLE
Add flag to export metrics with node name

### DIFF
--- a/emq_exporter.go
+++ b/emq_exporter.go
@@ -163,12 +163,13 @@ func (e *Exporter) add(fqName, help string, value float64) {
 
 func main() {
 	var (
-		listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9540").String()
-		metricsPath   = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		emqURI        = kingpin.Flag("emq.uri", "HTTP API address of the EMQ node.").Default("http://127.0.0.1:18083").Short('u').String()
-		emqCreds      = kingpin.Flag("emq.creds-file", "Path to json file containing emq credentials").Default("./auth.json").Short('f').String()
-		emqNodeName   = kingpin.Flag("emq.node", "Node name of the emq node to scrape.").Default("emq@127.0.0.1").Short('n').String()
-		emqAPIVersion = kingpin.Flag("emq.api-version", "The API version used by EMQ. Valid values: [v2, v3]").Default("v2").Enum("v2", "v3")
+		listenAddress     = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9540").String()
+		metricsPath       = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+		emqURI            = kingpin.Flag("emq.uri", "HTTP API address of the EMQ node.").Default("http://127.0.0.1:18083").Short('u').String()
+		emqCreds          = kingpin.Flag("emq.creds-file", "Path to json file containing emq credentials").Default("./auth.json").Short('f').String()
+		emqNodeName       = kingpin.Flag("emq.node", "Node name of the emq node to scrape.").Default("emq@127.0.0.1").Short('n').String()
+		emqAPIVersion     = kingpin.Flag("emq.api-version", "The API version used by EMQ. Valid values: [v2, v3]").Default("v2").Enum("v2", "v3")
+		emqExportNodeName = kingpin.Flag("emq.export-node-name", "Export metrics with node name prefix. Example: emq_node1_nodes_connections").Bool()
 	)
 
 	log.AddFlags(kingpin.CommandLine)
@@ -187,7 +188,7 @@ func main() {
 	log.Infoln("Starting emq_exporter")
 	log.Infof("Version %s (git-%s)", GitTag, GitCommit)
 
-	c := client.NewClient(*emqURI, *emqNodeName, *emqAPIVersion, username, password)
+	c := client.NewClient(*emqURI, *emqNodeName, *emqAPIVersion, username, password, *emqExportNodeName)
 
 	exporter := NewExporter(c)
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Client", func() {
 			"v3",
 			"admin",
 			"public",
+			false,
 		)
 	})
 


### PR DESCRIPTION
Hi, @HagaiBarel 

I added a flag (`emq.export-node-name`) to be able to export metrics for multiple nodes without overlapping.
It adds the node name to the exported metrics as a prefix. 
For example if the node name is `node1@127.0.0.1` the exported metrics will look like this `emq_node1_nodes_connections` instead of `emq_nodes_connections`
