### PR TITLE
bugfix: not a valid metric name  source=emq_exporter.go:99

### DIFF
--- a/emq_exporter.go
+++ b/emq_exporter.go
@@ -94,6 +94,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 	e.mu.Unlock()
 
 	for _, i := range metricList {
+		i.name = strings.Replace(i.name, ".", "_", -1)
 		m, err := newMetric(i)
 		if err != nil {
 			log.Errorf("newMetric: %v", err)


### PR DESCRIPTION
https://github.com/nuvo/emq_exporter/issues/17

【emq  version: 3.2】